### PR TITLE
ajuste SolicitacaoController e seu teste

### DIFF
--- a/src/main/java/br/com/proposta/api/controllers/SolicitacaoController.java
+++ b/src/main/java/br/com/proposta/api/controllers/SolicitacaoController.java
@@ -16,17 +16,12 @@ import br.com.proposta.api.dto.SolicitacaoDto;
 import br.com.proposta.api.dto.SolicitacaoRepostaDto;
 import br.com.proposta.api.entities.Proposta;
 import br.com.proposta.api.entities.Solicitacao;
-import br.com.proposta.api.entities.Veiculo;
 import br.com.proposta.api.services.PropostaService;
 import br.com.proposta.api.services.SolicitacaoService;
-import br.com.proposta.api.services.VeiculoService;
 
 @RestController
 @RequestMapping("financiamento/v1/solicitacoes")
 public class SolicitacaoController {
-
-	@Autowired
-	private VeiculoService veiculoService;
 
 	@Autowired
 	private SolicitacaoService solicitacaoService;
@@ -36,11 +31,7 @@ public class SolicitacaoController {
 	
 	@PostMapping
 	public ResponseEntity<SolicitacaoRepostaDto> registraSolicitacao(@Valid @RequestBody SolicitacaoDto solicitacaoDto) {
-		Veiculo veiculo = new Veiculo(solicitacaoDto.getModelo(), solicitacaoDto.getAno(), solicitacaoDto.getValor());
-		Solicitacao solicitacao = new Solicitacao(solicitacaoDto.getNome(), solicitacaoDto.getEmail(),
-				solicitacaoDto.getCpf(), veiculo, null);
-
-		veiculoService.save(veiculo);
+		Solicitacao solicitacao = solicitacaoDto.solicitacaoFromDto(solicitacaoDto);
 		solicitacaoService.save(solicitacao);
 		return ResponseEntity.ok().body(new SolicitacaoRepostaDto(solicitacao));
 	}

--- a/src/main/java/br/com/proposta/api/dto/SolicitacaoDto.java
+++ b/src/main/java/br/com/proposta/api/dto/SolicitacaoDto.java
@@ -9,6 +9,9 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import br.com.proposta.api.entities.Solicitacao;
+import br.com.proposta.api.entities.Veiculo;
+import br.com.proposta.api.repositories.VeiculoRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,5 +48,10 @@ public class SolicitacaoDto implements Serializable {
 	@NotNull(message = "Valor do veículo é obrigatório")
 	@JsonProperty("valor_veiculo")
 	private BigDecimal valor;
+	
+	public Solicitacao solicitacaoFromDto(SolicitacaoDto solicitacaoDto) {
+		Veiculo veiculo = new Veiculo(solicitacaoDto.getModelo(), solicitacaoDto.getAno(), solicitacaoDto.getValor());
+		return new Solicitacao(solicitacaoDto.getNome(), solicitacaoDto.getEmail(), solicitacaoDto.getCpf(), veiculo, null);
+	}
 	
 }

--- a/src/main/java/br/com/proposta/api/services/PropostaService.java
+++ b/src/main/java/br/com/proposta/api/services/PropostaService.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class PropostaService {
-	
+
 	private static BigDecimal JUROS_POR_PARCELA = BigDecimal.valueOf(1.2);
 	private static Integer QUANTIDADE_PARCELAS = 36;
 
@@ -37,11 +37,12 @@ public class PropostaService {
 	public Proposta save(Proposta proposta) {
 		return repository.save(proposta);
 	}
-	
+
 	public Proposta gerarProposta(Solicitacao solicitacao) {
 		BigDecimal valorVeiculo = solicitacao.getVeiculo().getValor();
 		BigDecimal valorParcela = calculaValorDaParcela(valorVeiculo, QUANTIDADE_PARCELAS, JUROS_POR_PARCELA);
 		BigDecimal valorTotal = calculaValorTotalDaProposta(QUANTIDADE_PARCELAS, valorParcela);
+		
 		Proposta proposta = new Proposta(TipoPagamento.BOLETO, valorTotal, valorVeiculo, QUANTIDADE_PARCELAS,
 				valorParcela, JUROS_POR_PARCELA);
 

--- a/src/test/java/br/com/proposta/api/controllers/SolicitacaoControllerTest.java
+++ b/src/test/java/br/com/proposta/api/controllers/SolicitacaoControllerTest.java
@@ -29,7 +29,6 @@ import br.com.proposta.api.entities.Solicitacao;
 import br.com.proposta.api.entities.Veiculo;
 import br.com.proposta.api.services.PropostaService;
 import br.com.proposta.api.services.SolicitacaoService;
-import br.com.proposta.api.services.VeiculoService;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(SolicitacaoController.class)
@@ -37,9 +36,6 @@ class SolicitacaoControllerTest {
 
 	@MockBean
 	private SolicitacaoService solicitacaoService;
-
-	@MockBean
-	private VeiculoService veiculoService;
 
 	@MockBean
 	private PropostaService propostaService;
@@ -68,14 +64,12 @@ class SolicitacaoControllerTest {
 		Solicitacao solicitacao = new Solicitacao(nome, email, cpf, veiculo, null);
 		SolicitacaoDto solicitacaoDto = new SolicitacaoDto(nome, email, cpf, modelo, ano, valor);
 
-		given(veiculoService.save(any(Veiculo.class))).willReturn(veiculo);
 		given(solicitacaoService.save(any(Solicitacao.class))).willReturn(solicitacao);
 
 		MockHttpServletResponse response = mockMvc.perform(post("/financiamento/v1/solicitacoes")
 				.contentType(MediaType.APPLICATION_JSON).content(jsonInput.write(solicitacaoDto).getJson())).andReturn()
 				.getResponse();
 
-		verify(veiculoService).save(veiculo);
 		verify(solicitacaoService).save(solicitacao);
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
 		assertThat(response.getContentAsString())


### PR DESCRIPTION
O comando `solicitacaoFromDto(solicitacaoDto)` converte uma SolicitacaoDto em uma Solicitacao, além disso **cria um `Veiculo` e associa ele a Solicitacao.** <br>
O `private VeiculoService veiculoService` foi removido de `SolicitacaoController` porque o **Spring Data** salva a entidade Veiculo associada a Proposta  em  `solicitacaoFromDto(solicitacaoDto)` automaticamente.<br>
Também foi preciso alterar os  **testes** de `SolicitacaoController` já que o `VeiculoService` não é mais usado no `SolicitacaoController`.